### PR TITLE
Add missing build relationships

### DIFF
--- a/Sources/Models/BuildRelationship.swift
+++ b/Sources/Models/BuildRelationship.swift
@@ -14,12 +14,13 @@ public enum BuildRelationship: Codable {
     case betaAppReviewDetail(BetaAppReviewDetail)
     case buildBetaDetail(BuildBetaDetail)
     case preReleaseVersion(PrereleaseVersion)
+    case betaAppReviewSubmission(BetaAppReviewSubmission)
 
     enum TypeKeys: String, CodingKey {
         case type
     }
     enum CodingKeys: String, Decodable, CodingKey {
-        case apps, builds, betaTesters, betaAppReviewDetails,buildBetaDetails, preReleaseVersions
+        case apps, builds, betaTesters, betaAppReviewDetails,buildBetaDetails, preReleaseVersions, betaAppReviewSubmissions
     }
 
     public init(from decoder: Decoder) throws {
@@ -36,6 +37,8 @@ public enum BuildRelationship: Codable {
           self = try .buildBetaDetail(BuildBetaDetail(from: decoder))
         case .preReleaseVersions:
           self = try .preReleaseVersion(PrereleaseVersion(from: decoder))
+        case .betaAppReviewSubmissions:
+          self = try .betaAppReviewSubmission(BetaAppReviewSubmission(from: decoder))
         }
     }
     
@@ -52,6 +55,8 @@ public enum BuildRelationship: Codable {
         case .buildBetaDetail(let value):
           try value.encode(to: encoder)
         case .preReleaseVersion(let value):
+          try value.encode(to: encoder)
+        case .betaAppReviewSubmission(let value):
           try value.encode(to: encoder)
         }
     }

--- a/Sources/Models/BuildRelationship.swift
+++ b/Sources/Models/BuildRelationship.swift
@@ -20,7 +20,7 @@ public enum BuildRelationship: Codable {
         case type
     }
     enum CodingKeys: String, Decodable, CodingKey {
-        case apps, builds, betaTesters, betaAppReviewDetails,buildBetaDetails, preReleaseVersions, betaAppReviewSubmissions
+        case apps, builds, betaTesters, betaAppReviewDetails, buildBetaDetails, preReleaseVersions, betaAppReviewSubmissions
     }
 
     public init(from decoder: Decoder) throws {

--- a/Sources/Models/BuildRelationship.swift
+++ b/Sources/Models/BuildRelationship.swift
@@ -11,12 +11,15 @@ public enum BuildRelationship: Codable {
     case app(App)
     case build(Build)
     case betaTester(BetaTester)
-    
+    case betaAppReviewDetail(BetaAppReviewDetail)
+    case buildBetaDetail(BuildBetaDetail)
+    case preReleaseVersion(PrereleaseVersion)
+
     enum TypeKeys: String, CodingKey {
         case type
     }
     enum CodingKeys: String, Decodable, CodingKey {
-        case apps, builds, betaTesters
+        case apps, builds, betaTesters, betaAppReviewDetails,buildBetaDetails, preReleaseVersions
     }
 
     public init(from decoder: Decoder) throws {
@@ -27,6 +30,12 @@ public enum BuildRelationship: Codable {
             self = try .build(Build(from: decoder))
         case .betaTesters:
             self = try .betaTester(BetaTester(from: decoder))
+        case .betaAppReviewDetails:
+          self = try .betaAppReviewDetail(BetaAppReviewDetail(from: decoder))
+        case .buildBetaDetails:
+          self = try .buildBetaDetail(BuildBetaDetail(from: decoder))
+        case .preReleaseVersions:
+          self = try .preReleaseVersion(PrereleaseVersion(from: decoder))
         }
     }
     
@@ -38,6 +47,12 @@ public enum BuildRelationship: Codable {
             try value.encode(to: encoder)
         case .betaTester(let value):
             try value.encode(to: encoder)
+        case .betaAppReviewDetail(let value):
+          try value.encode(to: encoder)
+        case .buildBetaDetail(let value):
+          try value.encode(to: encoder)
+        case .preReleaseVersion(let value):
+          try value.encode(to: encoder)
         }
     }
 }

--- a/Tests/Models+Tests.swift
+++ b/Tests/Models+Tests.swift
@@ -92,3 +92,11 @@ extension BuildBetaDetail {
         relationships: nil,
         links: .test)
 }
+
+extension BetaAppReviewSubmission {
+    static var test = BetaAppReviewSubmission(
+        attributes: nil,
+        id: "id",
+        links: .test,
+        relationships: nil)
+}

--- a/Tests/Models+Tests.swift
+++ b/Tests/Models+Tests.swift
@@ -84,3 +84,11 @@ extension BetaTester {
         relationships: nil,
         links: .test)
 }
+
+extension BuildBetaDetail {
+    static var test = BuildBetaDetail(
+        attributes: nil,
+        id: "id",
+        relationships: nil,
+        links: .test)
+}

--- a/Tests/Models/BuildRelationshipTests.swift
+++ b/Tests/Models/BuildRelationshipTests.swift
@@ -26,7 +26,8 @@ final class BuildRelationshipTests: XCTestCase {
             BuildRelationship.build(.test),
             BuildRelationship.betaAppReviewDetail(.test),
             BuildRelationship.buildBetaDetail(.test),
-            BuildRelationship.preReleaseVersion(.test)
+            BuildRelationship.preReleaseVersion(.test),
+            BuildRelationship.betaAppReviewSubmission(.test)
         ]
         for relationship in allCases {
             let encoded = try? encoder.encode(relationship)

--- a/Tests/Models/BuildRelationshipTests.swift
+++ b/Tests/Models/BuildRelationshipTests.swift
@@ -23,7 +23,10 @@ final class BuildRelationshipTests: XCTestCase {
         let allCases = [
             BuildRelationship.app(.test),
             BuildRelationship.betaTester(.test),
-            BuildRelationship.build(.test)
+            BuildRelationship.build(.test),
+            BuildRelationship.betaAppReviewDetail(.test),
+            BuildRelationship.buildBetaDetail(.test),
+            BuildRelationship.preReleaseVersion(.test)
         ]
         for relationship in allCases {
             let encoded = try? encoder.encode(relationship)


### PR DESCRIPTION
These are the possible build relationships
https://developer.apple.com/documentation/appstoreconnectapi/build/relationships
Currently the SDK supports only 3 relationships.
Adding the missing one that I need for the CLI tool.
