### PR TITLE
Add nextLimit property to PagedDocumentLinks and respect it in Endpoints

### DIFF
--- a/Sources/Endpoints/Provisioning/Bundle IDs/ListBundleIds.swift
+++ b/Sources/Endpoints/Provisioning/Bundle IDs/ListBundleIds.swift
@@ -28,7 +28,11 @@ extension APIEndpoint where T == BundleIdsResponse {
         if let filter = filter { parameters.add(filter) }
         if let include = include { parameters.add(include) }
         if let sort = sort { parameters.add(sort) }
-        if let limit = limit { parameters["limit"] = limit }
+        if let limit = limit {
+            parameters["limit"] = limit
+        } else if let nextLimit = next?.nextLimit {
+            parameters["limit"] = nextLimit
+        }
         if let nextCursor = next?.nextCursor { parameters["cursor"] = nextCursor }
         
         return APIEndpoint(

--- a/Sources/Endpoints/Provisioning/Certificates/ListDownloadCertificates.swift
+++ b/Sources/Endpoints/Provisioning/Certificates/ListDownloadCertificates.swift
@@ -25,7 +25,11 @@ extension APIEndpoint where T == CertificatesResponse {
         if let fields = fields { parameters.add(fields) }
         if let filter = filter { parameters.add(filter) }
         if let sort = sort { parameters.add(sort) }
-        if let limit = limit { parameters["limit"] = limit }
+        if let limit = limit {
+            parameters["limit"] = limit
+        } else if let nextLimit = next?.nextLimit {
+            parameters["limit"] = nextLimit
+        }
         if let nextCursor = next?.nextCursor { parameters["cursor"] = nextCursor }
         return APIEndpoint(
             path: "certificates",

--- a/Sources/Endpoints/Provisioning/Devices/ListDevices.swift
+++ b/Sources/Endpoints/Provisioning/Devices/ListDevices.swift
@@ -21,7 +21,11 @@ extension APIEndpoint where T == DevicesResponse {
         if let fields = fields { parameters.add(fields) }
         if let filter = filter { parameters.add(filter) }
         if let sort = sort { parameters.add(sort) }
-        if let limit = limit { parameters["limit"] = limit }
+        if let limit = limit {
+            parameters["limit"] = limit
+        } else if let nextLimit = next?.nextLimit {
+            parameters["limit"] = nextLimit
+        }
         if let nextCursor = next?.nextCursor { parameters["cursor"] = nextCursor }
         
         return APIEndpoint(

--- a/Sources/Endpoints/Provisioning/Profiles/ListDownloadProfiles.swift
+++ b/Sources/Endpoints/Provisioning/Profiles/ListDownloadProfiles.swift
@@ -23,7 +23,11 @@ extension APIEndpoint where T == ProfilesResponse {
         if let filter = filter { parameters.add(filter) }
         if let include = include { parameters.add(include) }
         if let sort = sort { parameters.add(sort) }
-        if let limit = limit { parameters.add(limit) }
+        if let limit = limit {
+            parameters.add(limit)
+        } else if let nextLimit = next?.nextLimit {
+            parameters["limit"] = nextLimit
+        }
         if let nextCursor = next?.nextCursor { parameters["cursor"] = nextCursor }
 
         return APIEndpoint(

--- a/Sources/Endpoints/TestFlight/App Encryption Declarations/ListAppEncryptionDeclarations.swift
+++ b/Sources/Endpoints/TestFlight/App Encryption Declarations/ListAppEncryptionDeclarations.swift
@@ -25,7 +25,11 @@ extension APIEndpoint where T == AppEncryptionDeclarationsResponse {
         if let fields = fields { parameters.add(fields) }
         if let filter = filter { parameters.add(filter) }
         if let include = include { parameters.add(include) }
-        if let limit = limit { parameters["limit"] = limit }
+        if let limit = limit {
+            parameters["limit"] = limit
+        } else if let nextLimit = next?.nextLimit {
+            parameters["limit"] = nextLimit
+        }
         if let nextCursor = next?.nextCursor { parameters["cursor"] = nextCursor }
         return APIEndpoint(
             path: "appEncryptionDeclarations",

--- a/Sources/Endpoints/TestFlight/Apps/ListBetaAppLocalizationsOfApp.swift
+++ b/Sources/Endpoints/TestFlight/Apps/ListBetaAppLocalizationsOfApp.swift
@@ -21,7 +21,11 @@ extension APIEndpoint where T == BetaAppLocalizationsResponse {
         next: PagedDocumentLinks? = nil) -> APIEndpoint {
         var parameters = [String: Any]()
         if let fields = fields { parameters.add(fields) }
-        if let limit = limit { parameters["limit"] = limit }
+        if let limit = limit {
+            parameters["limit"] = limit
+        } else if let nextLimit = next?.nextLimit {
+            parameters["limit"] = nextLimit
+        }
         if let nextCursor = next?.nextCursor { parameters["cursor"] = nextCursor }
         return APIEndpoint(
             path: "apps/\(id)/betaAppLocalizations",

--- a/Sources/Endpoints/TestFlight/Apps/ListBetaGroupsForApp.swift
+++ b/Sources/Endpoints/TestFlight/Apps/ListBetaGroupsForApp.swift
@@ -21,7 +21,11 @@ extension APIEndpoint where T == BetaGroupsResponse {
         next: PagedDocumentLinks? = nil) -> APIEndpoint {
         var parameters = [String: Any]()
         if let fields = fields { parameters.add(fields) }
-        if let limit = limit { parameters["limit"] = limit }
+        if let limit = limit {
+            parameters["limit"] = limit
+        } else if let nextLimit = next?.nextLimit {
+            parameters["limit"] = nextLimit
+        }
         if let nextCursor = next?.nextCursor { parameters["cursor"] = nextCursor }
         return APIEndpoint(
             path: "apps/\(id)/betaGroups",

--- a/Sources/Endpoints/TestFlight/Apps/ListBuildsOfApp.swift
+++ b/Sources/Endpoints/TestFlight/Apps/ListBuildsOfApp.swift
@@ -21,7 +21,11 @@ extension APIEndpoint where T == BuildsResponse {
         next: PagedDocumentLinks? = nil) -> APIEndpoint {
         var parameters = [String: Any]()
         if let fields = fields { parameters.add(fields) }
-        if let limit = limit { parameters["limit"] = limit }
+        if let limit = limit {
+            parameters["limit"] = limit
+        } else if let nextLimit = next?.nextLimit {
+            parameters["limit"] = nextLimit
+        }
         if let nextCursor = next?.nextCursor { parameters["cursor"] = nextCursor }
         return APIEndpoint(
             path: "apps/\(id)/builds",

--- a/Sources/Endpoints/TestFlight/Apps/ListPrereleaseVersionsForApp.swift
+++ b/Sources/Endpoints/TestFlight/Apps/ListPrereleaseVersionsForApp.swift
@@ -21,7 +21,11 @@ extension APIEndpoint where T == PreReleaseVersionsResponse {
         next: PagedDocumentLinks? = nil) -> APIEndpoint {
         var parameters = [String: Any]()
         if let fields = fields { parameters.add(fields) }
-        if let limit = limit { parameters["limit"] = limit }
+        if let limit = limit {
+            parameters["limit"] = limit
+        } else if let nextLimit = next?.nextLimit {
+            parameters["limit"] = nextLimit
+        }
         if let nextCursor = next?.nextCursor { parameters["cursor"] = nextCursor }
         return APIEndpoint(
             path: "apps/\(id)/preReleaseVersions",

--- a/Sources/Endpoints/TestFlight/Beta App Localizations/ListBetaAppLocalizations.swift
+++ b/Sources/Endpoints/TestFlight/Beta App Localizations/ListBetaAppLocalizations.swift
@@ -26,7 +26,11 @@ extension APIEndpoint where T == BetaAppLocalizationsResponse {
         if let fields = fields { parameters.add(fields) }
         if let filter = filter { parameters.add(filter) }
         if let include = include { parameters.add(include) }
-        if let limit = limit { parameters["limit"] = limit }
+        if let limit = limit {
+            parameters["limit"] = limit
+        } else if let nextLimit = next?.nextLimit {
+            parameters["limit"] = nextLimit
+        }
         if let nextCursor = next?.nextCursor { parameters["cursor"] = nextCursor }
         return APIEndpoint(
             path: "betaAppLocalizations",

--- a/Sources/Endpoints/TestFlight/Beta App Review Detail/ListBetaAppReviewDetails.swift
+++ b/Sources/Endpoints/TestFlight/Beta App Review Detail/ListBetaAppReviewDetails.swift
@@ -25,7 +25,11 @@ extension APIEndpoint where T == BetaAppReviewDetailsResponse {
         if let fields = fields { parameters.add(fields) }
         if let filter = filter { parameters.add(filter) }
         if let include = include { parameters.add(include) }
-        if let limit = limit { parameters["limit"] = limit }
+        if let limit = limit {
+            parameters["limit"] = limit
+        } else if let nextLimit = next?.nextLimit {
+            parameters["limit"] = nextLimit
+        }
         if let nextCursor = next?.nextCursor { parameters["cursor"] = nextCursor }
         return APIEndpoint(path: "betaAppReviewDetails", method: .get, parameters: parameters)
     }

--- a/Sources/Endpoints/TestFlight/Beta App Review Submissions/ListBetaAppReviewSubmissions.swift
+++ b/Sources/Endpoints/TestFlight/Beta App Review Submissions/ListBetaAppReviewSubmissions.swift
@@ -25,7 +25,11 @@ extension APIEndpoint where T == BetaAppReviewSubmissionsResponse {
         if let fields = fields { parameters.add(fields) }
         if let filter = filter { parameters.add(filter) }
         if let include = include { parameters.add(include) }
-        if let limit = limit { parameters["limit"] = limit }
+        if let limit = limit {
+            parameters["limit"] = limit
+        } else if let nextLimit = next?.nextLimit {
+            parameters["limit"] = nextLimit
+        }
         if let nextCursor = next?.nextCursor { parameters["cursor"] = nextCursor }
         return APIEndpoint(path: "betaAppReviewSubmissions", method: .get, parameters: parameters)
     }

--- a/Sources/Endpoints/TestFlight/Beta Build Localizations/ListBetaBuildLocalizations.swift
+++ b/Sources/Endpoints/TestFlight/Beta Build Localizations/ListBetaBuildLocalizations.swift
@@ -25,7 +25,11 @@ extension APIEndpoint where T == BetaBuildLocalizationsResponse {
         if let fields = fields { parameters.add(fields) }
         if let filter = filter { parameters.add(filter) }
         if let include = include { parameters.add(include) }
-        if let limit = limit { parameters["limit"] = limit }
+        if let limit = limit {
+            parameters["limit"] = limit
+        } else if let nextLimit = next?.nextLimit {
+            parameters["limit"] = nextLimit
+        }
         if let nextCursor = next?.nextCursor { parameters["cursor"] = nextCursor }
         return APIEndpoint(
             path: "betaBuildLocalizations",

--- a/Sources/Endpoints/TestFlight/Beta Groups/ListBetaGroups.swift
+++ b/Sources/Endpoints/TestFlight/Beta Groups/ListBetaGroups.swift
@@ -27,7 +27,11 @@ extension APIEndpoint where T == BetaGroupsResponse {
         if let fields = fields { parameters.add(fields) }
         if let filter = filter { parameters.add(filter) }
         if let include = include { parameters.add(include) }
-        if let limit = limit { parameters.add(limit) }
+        if let limit = limit {
+            parameters.add(limit)
+        } else if let nextLimit = next?.nextLimit {
+            parameters["limit"] = nextLimit
+        }
         if let sort = sort { parameters.add(sort) }
         if let nextCursor = next?.nextCursor { parameters["cursor"] = nextCursor }
         return APIEndpoint(path: "betaGroups", method: .get, parameters: parameters)

--- a/Sources/Endpoints/TestFlight/Beta Groups/ListBetaTestersInBetaGroup.swift
+++ b/Sources/Endpoints/TestFlight/Beta Groups/ListBetaTestersInBetaGroup.swift
@@ -20,7 +20,11 @@ extension APIEndpoint where T == BetaTestersResponse {
         fields: [ListBetaTestersInBetaGroup.Field]? = nil,
         next: PagedDocumentLinks? = nil) -> APIEndpoint {
         var parameters = [String: Any]()
-        if let limit = limit { parameters["limit"] = limit }
+        if let limit = limit {
+            parameters["limit"] = limit
+        } else if let nextLimit = next?.nextLimit {
+            parameters["limit"] = nextLimit
+        }
         if let fields = fields { parameters.add(fields) }
         if let nextCursor = next?.nextCursor { parameters["cursor"] = nextCursor }
         return APIEndpoint(

--- a/Sources/Endpoints/TestFlight/Beta Groups/ListBuildsForBetaGroup.swift
+++ b/Sources/Endpoints/TestFlight/Beta Groups/ListBuildsForBetaGroup.swift
@@ -20,7 +20,11 @@ extension APIEndpoint where T == BuildsResponse {
         fields: [ListBuildsForBetaGroup.Field]? = nil,
         next: PagedDocumentLinks? = nil) -> APIEndpoint {
         var parameters = [String: Any]()
-        if let limit = limit { parameters["limit"] = limit }
+        if let limit = limit {
+            parameters["limit"] = limit
+        } else if let nextLimit = next?.nextLimit {
+            parameters["limit"] = nextLimit
+        }
         if let fields = fields { parameters.add(fields) }
         if let nextCursor = next?.nextCursor { parameters["cursor"] = nextCursor }
         return APIEndpoint(

--- a/Sources/Endpoints/TestFlight/Beta License Agreements/ListBetaLicenseAgreements.swift
+++ b/Sources/Endpoints/TestFlight/Beta License Agreements/ListBetaLicenseAgreements.swift
@@ -25,7 +25,11 @@ extension APIEndpoint where T == BetaLicenseAgreementsResponse {
         if let fields = fields { parameters.add(fields) }
         if let filter = filter { parameters.add(filter) }
         if let include = include { parameters.add(include) }
-        if let limit = limit { parameters["limit"] = limit }
+        if let limit = limit {
+            parameters["limit"] = limit
+        } else if let nextLimit = next?.nextLimit {
+            parameters["limit"] = nextLimit
+        }
         if let nextCursor = next?.nextCursor { parameters["cursor"] = nextCursor }
         return APIEndpoint(path: "betaLicenseAgreements", method: .get, parameters: parameters)
     }

--- a/Sources/Endpoints/TestFlight/BetaTesters/ListAppsForBetaTester.swift
+++ b/Sources/Endpoints/TestFlight/BetaTesters/ListAppsForBetaTester.swift
@@ -20,7 +20,11 @@ extension APIEndpoint where T == AppsResponse {
         fields: [ListAppsForBetaTester.Field]? = nil,
         next: PagedDocumentLinks? = nil) -> APIEndpoint {
         var parameters = [String: Any]()
-        if let limit = limit { parameters["limit"] = limit }
+        if let limit = limit {
+            parameters["limit"] = limit
+        } else if let nextLimit = next?.nextLimit {
+            parameters["limit"] = nextLimit
+        }
         if let fields = fields { parameters.add(fields) }
         if let nextCursor = next?.nextCursor { parameters["cursor"] = nextCursor }
         return APIEndpoint(

--- a/Sources/Endpoints/TestFlight/BetaTesters/ListBetaGroupsToWhichBetaTesterBelongs.swift
+++ b/Sources/Endpoints/TestFlight/BetaTesters/ListBetaGroupsToWhichBetaTesterBelongs.swift
@@ -20,7 +20,11 @@ extension APIEndpoint where T == BetaGroupsResponse {
         fields: [ListBetaGroupsToWhichBetaTesterBelongs.Field]? = nil,
         next: PagedDocumentLinks? = nil) -> APIEndpoint {
         var parameters = [String: Any]()
-        if let limit = limit { parameters["limit"] = limit }
+        if let limit = limit {
+            parameters["limit"] = limit
+        } else if let nextLimit = next?.nextLimit {
+            parameters["limit"] = nextLimit
+        }
         if let fields = fields { parameters.add(fields) }
         if let nextCursor = next?.nextCursor { parameters["cursor"] = nextCursor }
         return APIEndpoint(

--- a/Sources/Endpoints/TestFlight/BetaTesters/ListBetaTesters.swift
+++ b/Sources/Endpoints/TestFlight/BetaTesters/ListBetaTesters.swift
@@ -27,7 +27,11 @@ extension APIEndpoint where T == BetaTestersResponse {
         if let fields = fields { parameters.add(fields) }
         if let filter = filter { parameters.add(filter) }
         if let include = include { parameters.add(include) }
-        if let limit = limit { parameters.add(limit) }
+        if let limit = limit {
+            parameters.add(limit)
+        } else if let nextLimit = next?.nextLimit {
+            parameters["limit"] = nextLimit
+        }
         if let sort = sort { parameters.add(sort) }
         if let nextCursor = next?.nextCursor { parameters["cursor"] = nextCursor }
         return APIEndpoint(path: "betaTesters", method: .get, parameters: parameters)

--- a/Sources/Endpoints/TestFlight/BetaTesters/ListBuildsAssignedToBetaTester.swift
+++ b/Sources/Endpoints/TestFlight/BetaTesters/ListBuildsAssignedToBetaTester.swift
@@ -20,7 +20,11 @@ extension APIEndpoint where T == BuildsResponse {
         fields: [ListBuildsAssignedToBetaTester.Field]? = nil,
         next: PagedDocumentLinks? = nil) -> APIEndpoint {
         var parameters = [String: Any]()
-        if let limit = limit { parameters["limit"] = limit }
+        if let limit = limit {
+            parameters["limit"] = limit
+        } else if let nextLimit = next?.nextLimit {
+            parameters["limit"] = nextLimit
+        }
         if let fields = fields { parameters.add(fields) }
         if let nextCursor = next?.nextCursor { parameters["cursor"] = nextCursor }
         return APIEndpoint(

--- a/Sources/Endpoints/TestFlight/Build Beta Details/ListBuildBetaDetails.swift
+++ b/Sources/Endpoints/TestFlight/Build Beta Details/ListBuildBetaDetails.swift
@@ -25,7 +25,11 @@ extension APIEndpoint where T == BuildBetaDetailsResponse {
         if let fields = fields { parameters.add(fields) }
         if let filter = filter { parameters.add(filter) }
         if let include = include { parameters.add(include) }
-        if let limit = limit { parameters["limit"] = limit }
+        if let limit = limit {
+            parameters["limit"] = limit
+        } else if let nextLimit = next?.nextLimit {
+            parameters["limit"] = nextLimit
+        }
         if let nextCursor = next?.nextCursor { parameters["cursor"] = nextCursor }
         return APIEndpoint(path: "buildBetaDetails", method: .get, parameters: parameters)
     }

--- a/Sources/Endpoints/TestFlight/Builds/ListBetaBuildLocalizationsOfBuild.swift
+++ b/Sources/Endpoints/TestFlight/Builds/ListBetaBuildLocalizationsOfBuild.swift
@@ -21,7 +21,11 @@ extension APIEndpoint where T == BetaBuildLocalizationsResponse {
         next: PagedDocumentLinks? = nil) -> APIEndpoint {
         var parameters = [String: Any]()
         if let fields = fields { parameters.add(fields) }
-        if let limit = limit { parameters["limit"] = limit }
+        if let limit = limit {
+            parameters["limit"] = limit
+        } else if let nextLimit = next?.nextLimit {
+            parameters["limit"] = nextLimit
+        }
         if let nextCursor = next?.nextCursor { parameters["cursor"] = nextCursor }
         return APIEndpoint(
             path: "builds/\(id)/betaBuildLocalizations",

--- a/Sources/Endpoints/TestFlight/Builds/ListBuilds.swift
+++ b/Sources/Endpoints/TestFlight/Builds/ListBuilds.swift
@@ -27,7 +27,11 @@ extension APIEndpoint where T == BuildsResponse {
         if let fields = fields { parameters.add(fields) }
         if let filter = filter { parameters.add(filter) }
         if let include = include { parameters.add(include) }
-        if let limit = limit { parameters.add(limit) }
+        if let limit = limit {
+            parameters.add(limit)
+        } else if let nextLimit = next?.nextLimit {
+            parameters["limit"] = nextLimit
+        }
         if let sort = sort { parameters.add(sort) }
         if let nextCursor = next?.nextCursor { parameters["cursor"] = nextCursor }
         return APIEndpoint(

--- a/Sources/Endpoints/TestFlight/Builds/ListIndividualTestersForBuild.swift
+++ b/Sources/Endpoints/TestFlight/Builds/ListIndividualTestersForBuild.swift
@@ -20,7 +20,11 @@ extension APIEndpoint where T == BetaTestersResponse {
         fields: [ListIndividualTestersForBuild.Field]? = nil,
         next: PagedDocumentLinks? = nil) -> APIEndpoint {
         var parameters = [String: Any]()
-        if let limit = limit { parameters["limit"] = limit }
+        if let limit = limit {
+            parameters["limit"] = limit
+        } else if let nextLimit = next?.nextLimit {
+            parameters["limit"] = nextLimit
+        }
         if let fields = fields { parameters.add(fields) }
         if let nextCursor = next?.nextCursor { parameters["cursor"] = nextCursor }
         return APIEndpoint(path: "builds/\(id)/individualTesters", method: .get, parameters: parameters)

--- a/Sources/Endpoints/TestFlight/Prerelease Versions/ListBuildsOfPrereleaseVersion.swift
+++ b/Sources/Endpoints/TestFlight/Prerelease Versions/ListBuildsOfPrereleaseVersion.swift
@@ -20,7 +20,11 @@ extension APIEndpoint where T == BuildsResponse {
         limit: Int? = nil,
         next: PagedDocumentLinks? = nil) -> APIEndpoint {
         var parameters = [String: Any]()
-        if let limit = limit { parameters["limit"] = limit }
+        if let limit = limit {
+            parameters["limit"] = limit
+        } else if let nextLimit = next?.nextLimit {
+            parameters["limit"] = nextLimit
+        }
         if let fields = fields { parameters.add(fields) }
         if let nextCursor = next?.nextCursor { parameters["cursor"] = nextCursor }
         return APIEndpoint(path: "preReleaseVersions/\(id)/builds", method: .get, parameters: parameters)

--- a/Sources/Endpoints/TestFlight/Prerelease Versions/ListPrereleaseVersions.swift
+++ b/Sources/Endpoints/TestFlight/Prerelease Versions/ListPrereleaseVersions.swift
@@ -27,7 +27,11 @@ extension APIEndpoint where T == PreReleaseVersionsResponse {
         if let fields = fields { parameters.add(fields) }
         if let filter = filter { parameters.add(filter) }
         if let include = include { parameters.add(include) }
-        if let limit = limit { parameters.add(limit) }
+        if let limit = limit {
+            parameters.add(limit)
+        } else if let nextLimit = next?.nextLimit {
+            parameters["limit"] = nextLimit
+        }
         if let sort = sort { parameters.add(sort) }
         if let nextCursor = next?.nextCursor { parameters["cursor"] = nextCursor }
         return APIEndpoint(path: "preReleaseVersions", method: .get, parameters: parameters)

--- a/Sources/Endpoints/Users Invitations/ListAppsVisibleToInvitedUser.swift
+++ b/Sources/Endpoints/Users Invitations/ListAppsVisibleToInvitedUser.swift
@@ -21,7 +21,11 @@ extension APIEndpoint where T == AppsResponse {
         limit: Int? = nil,
         next: PagedDocumentLinks? = nil) -> APIEndpoint {
         var parameters = [String: Any]()
-        if let limit = limit { parameters["limit"] = limit }
+        if let limit = limit {
+            parameters["limit"] = limit
+        } else if let nextLimit = next?.nextLimit {
+            parameters["limit"] = nextLimit
+        }
         if let fields = fields { parameters.add(fields) }
         if let nextCursor = next?.nextCursor { parameters["cursor"] = nextCursor }
         return APIEndpoint(path: "userInvitations/\(id)/visibleApps", method: .get, parameters: parameters)

--- a/Sources/Endpoints/Users Invitations/ListInvitedUsers.swift
+++ b/Sources/Endpoints/Users Invitations/ListInvitedUsers.swift
@@ -27,7 +27,11 @@ extension APIEndpoint where T == UserInvitationsResponse {
         var parameters = [String: Any]()
         if let fields = fields { parameters.add(fields) }
         if let include = include { parameters.add(include) }
-        if let limit = limit { parameters.add(limit) }
+        if let limit = limit {
+            parameters.add(limit)
+        } else if let nextLimit = next?.nextLimit {
+            parameters["limit"] = nextLimit
+        }
         if let sort = sort { parameters.add(sort) }
         if let filter = filter { parameters.add(filter) }
         if let nextCursor = next?.nextCursor { parameters["cursor"] = nextCursor }

--- a/Sources/Endpoints/Users/ListAppsVisibleToUser.swift
+++ b/Sources/Endpoints/Users/ListAppsVisibleToUser.swift
@@ -20,7 +20,11 @@ extension APIEndpoint where T == AppsResponse {
         fields: [ListAppsVisibleToUser.Field]? = nil,
         next: PagedDocumentLinks? = nil) -> APIEndpoint {
         var parameters = [String: Any]()
-        if let limit = limit { parameters["limit"] = limit }
+        if let limit = limit {
+            parameters["limit"] = limit
+        } else if let nextLimit = next?.nextLimit {
+            parameters["limit"] = nextLimit
+        }
         if let fields = fields { parameters.add(fields) }
         if let nextCursor = next?.nextCursor { parameters["cursor"] = nextCursor }
         return APIEndpoint(path: "users/\(id)/visibleApps", method: .get, parameters: parameters)

--- a/Sources/Endpoints/Users/ListUsers.swift
+++ b/Sources/Endpoints/Users/ListUsers.swift
@@ -26,7 +26,11 @@ extension APIEndpoint where T == UsersResponse {
         var parameters = [String: Any]()
         if let fields = fields { parameters.add(fields) }
         if let include = include { parameters.add(include) }
-        if let limit = limit { parameters.add(limit) }
+        if let limit = limit {
+            parameters.add(limit)
+        } else if let nextLimit = next?.nextLimit {
+            parameters["limit"] = nextLimit
+        }
         if let sort = sort { parameters.add(sort) }
         if let filter = filter { parameters.add(filter) }
         if let nextCursor = next?.nextCursor { parameters["cursor"] = nextCursor }

--- a/Sources/Models/PagedDocumentLinks.swift
+++ b/Sources/Models/PagedDocumentLinks.swift
@@ -25,6 +25,11 @@ extension PagedDocumentLinks {
     var nextCursor: String? {
         return next?.value(for: "cursor")
     }
+
+    var nextLimit: String? {
+        return next?.value(for: "limit")
+    }
+
 }
 
 private extension URL {


### PR DESCRIPTION
This PR is for closing #109.

## Changes
- Add 
```
var nextLimit: String? {
    return next?.value(for: "limit")
}
```
to `PagedDocumentLinks`
- Use it in request parameters
```
if let limit = limit {
    parameters.add(limit)
} else if let nextLimit = next?.nextLimit {
    parameters["limit"] = nextLimit
}
```

This is just a workaround, please comment if you have other ideas, thanks.